### PR TITLE
Default to internal flash in example

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -6,7 +6,9 @@
         "*": {
             "platform.stdio-baud-rate": 115200,
             "platform.default-serial-baud-rate": 115200,
-            "platform.stdio-convert-newlines": 1
+            "platform.stdio-convert-newlines": 1,
+            "storage.storage_type": "TDB_INTERNAL",
+            "target.components_add": ["FLASHIAP"]
         }
     }
 }


### PR DESCRIPTION
Set the storage type to TDB_INTERNAL and add the component FLASHIAP for all targets in mbed_app.json so new targets, such as the NRF52840_DK, work by default. This fixes #7.