### PR TITLE
Add log compare test for kvstore example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,11 @@ Image: ./BUILD/K64F/ARM/mbed-os-example-kvstore.bin
 1. Open the UART of the board in your favorite UART viewing program. For
    example, `screen /dev/ttyACM0`.
 
-**Note:** The default serial port baud rate is 115200 bit/s.
+**Note:** The default serial port baud rate is 9600 bit/s.
           You may open serial term with:  
+
 ```
-mbed sterm -b 115200 -r
+mbed sterm -b 9600 -r
 ```
 
 Expected output:

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -4,8 +4,6 @@
             "storage.storage_type": "TDB_INTERNAL"
         },
         "*": {
-            "platform.stdio-baud-rate": 115200,
-            "platform.default-serial-baud-rate": 115200,
             "platform.stdio-convert-newlines": 1
         }
     }

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,5 +8,5 @@ mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\kvstore.bin --compare-lo
 ```
 
 
-More details about `htrun` are [here](https://github.com/ARMmbed/htrun#testing-mbed-os-examples).
+More details about `htrun` are [here](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests#testing-mbed-os-examples).
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,12 @@
+# Testing examples
+
+Examples are tested using tool [htrun](https://github.com/ARMmbed/mbed-os-tools/tree/master/packages/mbed-host-tests) and templated print log. 
+
+To run the test, use following command after you build the example:
+```
+mbedhtrun -d D: -p COM4 -m K64F -f .\BUILD\K64F\GCC_ARM\kvstore.bin --compare-log tests\kvstore.log
+```
+
+
+More details about `htrun` are [here](https://github.com/ARMmbed/htrun#testing-mbed-os-examples).
+

--- a/tests/kvstore.log
+++ b/tests/kvstore.log
@@ -1,0 +1,32 @@
+--- Mbed OS KVStore static API example ---
+kv_reset
+kv_reset -> 0
+kv_set first dummy key
+kv_set -> 0
+kv_get_info of first key
+kv_get_info -> 0
+kv_get_info key: \/kv\/dummy_key1
+kv_get_info info - size: 31, flags: 0
+kv_get first key
+kv_get -> 0
+kv_get key: \/kv\/dummy_key1
+kv_get value: kvstore_dummy_value_hello_world
+kv_set second dummy key
+kv_set -> 0
+kv_set third key with Confidentiality and Replay Protection flags
+kv_set -> 0
+kv_set Set 'Real' Key 1
+kv_set -> 0
+kv_set Set 'Real' Key 2 with flag write-once
+kv_set -> 0
+Removing 'Dummy' Keys
+1\) Removing dummy_key2
+2\) Removing dummy_auth_enc_key
+3\) Removing dummy_key1
+Remaining with 'Real' Keys:
+1\) real_key1
+2\) real_wo_key
+kv_remove write-once file - should fail!
+kv_remove -> 274
+kv_reset format kvstore \(including write-once\)
+kv_reset -> 0


### PR DESCRIPTION
Add a log compare test for this example for enable example CI testing
And change default baud rate to 9600 default,

I don't know if there is any justifiable reason to use the baud rate as 115200, I just change it to 9600 to make it is consistent with other examples, and it is going the make the test easier