### PR TITLE
CMake: link mbed-storage-kv-global-api

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(${APP_TARGET}
         mbed-storage-littlefs
         mbed-mbedtls
         mbed-storage-kvstore
+        mbed-storage-kv-global-api
         mbed-storage-qspif
         mbed-storage-flashiap
 )


### PR DESCRIPTION
Mutually depends on https://github.com/ARMmbed/mbed-os/pull/13908

Each sub-component of KVStore is turned into a separate CMake target library, to allow building only what an application needs.