### PR TITLE
Revert "CMake: link mbed-storage-kv-global-api"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ target_link_libraries(${APP_TARGET}
         mbed-storage-littlefs
         mbed-mbedtls
         mbed-storage-kvstore
-        mbed-storage-kv-global-api
         mbed-storage-qspif
         mbed-storage-flashiap
 )


### PR DESCRIPTION
Preparing so this can go in today to unblock other PRs.

Reverts ARMmbed/mbed-os-example-kvstore#60

For now, to unblock master Mbed OS. 