### PR TITLE
Bring back "CMake: link mbed-storage-kv-global-api" (#60)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(${APP_TARGET}
         mbed-storage-littlefs
         mbed-mbedtls
         mbed-storage-kvstore
+        mbed-storage-kv-global-api
         mbed-storage-qspif
         mbed-storage-flashiap
 )


### PR DESCRIPTION
Reverts #62 
This change is required for https://github.com/ARMmbed/mbed-os/pull/13908
@0xc0170 