### PR TITLE
Generate DeviceKey Root of Trust if SecureStore is enabled

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -20,12 +20,16 @@
 #include <string.h>
 #include "KVStore.h"
 #include "kvstore_global_api.h"
+#include "DeviceKey.h"
 
 using namespace mbed;
 
 #define EXAMPLE_KV_VALUE_LENGTH 64
 #define EXAMPLE_KV_KEY_LENGTH 32
 #define err_code(res) MBED_GET_ERROR_CODE(res)
+
+#define STR_EXPAND(tok) #tok
+#define STR(tok) STR_EXPAND(tok)
 
 void kv_store_global_api_example();
 
@@ -58,6 +62,11 @@ void kv_store_global_api_example()
     printf("kv_reset\n");
     res = kv_reset("/kv/");
     printf("kv_reset -> %d\n", err_code(res));
+
+    if (strcmp(STR(MBED_CONF_STORAGE_STORAGE_TYPE), "TDB_EXTERNAL") == 0) {
+        res = DeviceKey::get_instance().generate_root_of_trust();
+        printf("DeviceKey::get_instance().generate_root_of_trust() -> %d\n", res);
+    }
 
     /* Set First 'Dummy' Key/Value pair with unprotected clear value data */
     printf("kv_set first dummy key\n");


### PR DESCRIPTION
Fixes: #52 

Following https://github.com/ARMmbed/mbed-os/pull/12385, DeviceKey Root of Trust is _not_ implicitly generated anymore. The Root of Trust can be either auto generated with `DeviceKey::get_instance().generate_root_of_trust()`, or injected with `DeviceKey::device_inject_root_of_trust(...)`.

External TDB uses SecureStore which depends on DeviceKey ([here](https://github.com/ARMmbed/mbed-os/blob/f2278567d09b9ae9f4843e1d9d393526b9462783/storage/kvstore/kv_config/source/kv_config.cpp#L806-L827)), so we need to set up a Root of Trust by generating one. Note: `generate_root_of_trust()` depends on TRNG support, which is already a requirement for SecureStore so we don't need an extra check here.

Tested on K64F with SD card.

@ARMmbed/mbed-os-core 