### PR TITLE
CMake: Include only the libraries required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,9 @@ matrix:
         - pip install "Jinja2>=2.10.1,<2.11"
         - pip install "intelhex>=1.3,<=2.2.1"
       script:
-        - mbedtools checkout
-        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
-        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools deploy
+        - echo mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools compile -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
         - ccache -s
 
     - <<: *cmake-build-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,13 +27,7 @@ target_sources(${APP_TARGET}
 target_link_libraries(${APP_TARGET}
     PRIVATE
         mbed-os
-        mbed-storage-fat
-        mbed-storage-littlefs
-        mbed-mbedtls
         mbed-storage-kvstore
-        mbed-storage-kv-global-api
-        mbed-storage-qspif
-        mbed-storage-flashiap
 )
 
 mbed_set_post_build(${APP_TARGET})


### PR DESCRIPTION
Mbed OS now handles the dependencies.

Depends on: https://github.com/ARMmbed/mbed-os/pull/14065 and https://github.com/ARMmbed/mbed-os/pull/14079

Reviewers
@LDong-Arm @rajkan01 